### PR TITLE
resolve jira name

### DIFF
--- a/jirajumper/cache/cache.py
+++ b/jirajumper/cache/cache.py
@@ -26,6 +26,19 @@ class JiraCache(BaseModel):
     selected_issue_key: Optional[str] = None
 
 
+def field_key_by_name(jira: JIRA) -> FieldKeyByName:
+    """
+    Map field names to keys.
+
+    This is useful for `custom*` and the like: the field key can vary
+    among installations but the canonical name helps us to find that key.
+    """
+    return {
+        field['name']: field['key']
+        for field in jira.fields()
+    }
+
+
 @dataclass
 class GlobalOptions:
     """Global jeeves-jira configuration options."""

--- a/jirajumper/commands/clone.py
+++ b/jirajumper/commands/clone.py
@@ -12,19 +12,12 @@ def clone(
     """Clone a JIRA issue."""
     parent_issue = context.obj.current_issue
     parent_issue_fields = {
-        field.resolve_jira_field_name(
-            field_key_by_name=context.obj.field_key_by_name,
-        ): field.retrieve(
-            issue=parent_issue,
-            field_key_by_name=context.obj.field_key_by_name,
-        )
+        field.jira_name: field.retrieve(issue=parent_issue)
         for field in context.obj.fields
     }
 
     update_fields = {
-        update_field.resolve_jira_field_name(
-            field_key_by_name=context.obj.field_key_by_name,
-        ): kwargs[update_field.human_name]
+        update_field.jira_name: kwargs[update_field.human_name]
         for update_field in context.obj.fields
         if kwargs.get(update_field.human_name)
     }
@@ -40,7 +33,6 @@ def clone(
         raise JIRAUpdateFailed(
             errors=err.response.json().get('errors', {}),
             fields=context.obj.fields,
-            field_key_by_name=context.obj.field_key_by_name,
         ) from err
 
     rich.print(issue)

--- a/jirajumper/commands/select.py
+++ b/jirajumper/commands/select.py
@@ -97,20 +97,14 @@ def jump(
         rich.print(issue_url(client.server_url, issue.key))
 
         for print_field in context.obj.fields:
-            field_value = print_field.retrieve(
-                issue=issue,
-                field_key_by_name=context.obj.field_key_by_name,
-            )
+            field_value = print_field.retrieve(issue=issue)
             rich.print(f'  - {print_field.human_name}: {field_value}')
 
     else:
         echo(
             json.dumps(
                 {
-                    json_field.human_name: json_field.retrieve(
-                        issue=issue,
-                        field_key_by_name=context.obj.field_key_by_name,
-                    )
+                    json_field.human_name: json_field.retrieve(issue=issue)
                     for json_field in context.obj.fields
                 },
                 indent=2,

--- a/jirajumper/commands/update.py
+++ b/jirajumper/commands/update.py
@@ -21,15 +21,12 @@ class JIRAUpdateFailed(DocumentedError):
 
     errors: Dict[str, str]
     fields: JiraFieldsRepository
-    field_key_by_name: FieldKeyByName
 
     @property
     def formatted_errors(self) -> str:
         """Format the error list received from JIRA."""
         field_per_resolved_jira_name = {
-            field.resolve_jira_field_name(
-                field_key_by_name=self.field_key_by_name,
-            ): field
+            field.jira_name: field
             for field in self.fields
         }
 
@@ -64,10 +61,7 @@ def update(
         rich.print(f'  - {print_field.human_name} ≔ {human_value}')
 
     issue_fields = dict([
-        store_field.store(
-            human_value=human_value,
-            field_key_by_name=context.obj.field_key_by_name,
-        )
+        store_field.store(human_value=human_value)
         for store_field, human_value in fields_and_values
     ])
 
@@ -77,7 +71,6 @@ def update(
         raise JIRAUpdateFailed(
             errors=err.response.json().get('errors', {}),
             fields=context.obj.fields,
-            field_key_by_name=context.obj.field_key_by_name,
         ) from err
 
     rich.print('Updated!')

--- a/jirajumper/fields/defaults.py
+++ b/jirajumper/fields/defaults.py
@@ -67,8 +67,16 @@ DESCRIPTION = JiraField(
     description='JIRA task description body.',
 )
 
+ASSIGNEE = JiraField(
+    jira_name='assignee',
+    human_name='assignee',
+    description='Person the issue is assigned to.',
+    from_jira=lambda assignee: assignee and assignee.displayName,
+    to_jira=lambda assignee_name: {'name': assignee_name},
+)
+
 
 # TODO This should be configurable in configuration files or somehow else.
 FIELDS = JiraFieldsRepository([
-    VERSION, SUMMARY, STATUS, TYPE, EPIC_LINK, PROJECT, DESCRIPTION,
+    SUMMARY, VERSION, STATUS, TYPE, EPIC_LINK, PROJECT, ASSIGNEE, DESCRIPTION,
 ])


### PR DESCRIPTION
- Savepoint before I break everything
- Cosmetic change
- Update `jj --format json jump` logic to avoid usage of obsolete cached fields logic
- Remove bunch of dead code
- Transparently control the location of the cache file
- Implement `inv lint` and `inv format` commands
- Support for `jj update --epic` implemented
- Draft implementation for `jj clone`
- Resolve JIRA field names transparently and reduce boilerplate
