### PR TITLE
jj link

### DIFF
--- a/jirajumper/cache/cache.py
+++ b/jirajumper/cache/cache.py
@@ -1,6 +1,6 @@
-import json
 from dataclasses import dataclass
 from functools import cached_property
+from logging import Logger
 from pathlib import Path
 from typing import Optional
 
@@ -43,6 +43,7 @@ def field_key_by_name(jira: JIRA) -> FieldKeyByName:
 class GlobalOptions:
     """Global jeeves-jira configuration options."""
 
+    logger: Logger
     output_format: OutputFormat
     jira: JIRA
     cache_path: Path

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -13,7 +13,7 @@ from jirajumper.commands.clone import clone
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
 from jirajumper.commands.update import update
-from jirajumper.fields import FIELDS, JiraField
+from jirajumper.fields import FIELDS, JiraField, JiraFieldsRepository
 from jirajumper.models import OutputFormat
 
 app = Typer(
@@ -54,7 +54,7 @@ def global_options(
     context.obj = GlobalOptions(
         output_format=format,
         jira=jira(),
-        fields=list(resolved_fields),
+        fields=JiraFieldsRepository(resolved_fields),
         cache_path=cache_path,
     )
 
@@ -81,9 +81,9 @@ class AutoOptionsCommand(TyperCommand):
         ]
 
         existing_params = list(filterfalse(
-            lambda param: (
-                isinstance(param, TyperArgument) and
-                param.name == 'kwargs'
+            lambda existing_param: (
+                isinstance(existing_param, TyperArgument) and
+                existing_param.name == 'options'
             ),
             kwargs.get('params', []),
         ))

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -74,7 +74,7 @@ class AutoOptionsCommand(TyperCommand):
 
         custom_options = [
             click.Option(
-                [f'--{field.human_name}'],
+                [f'--{field.human_name.replace("_", "-")}'],
                 help=field.description,
             )
             for field in fields

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -14,6 +14,7 @@ from typer.core import TyperArgument, TyperCommand
 from jirajumper.cache.cache import GlobalOptions, field_key_by_name
 from jirajumper.client import jira
 from jirajumper.commands.clone import clone
+from jirajumper.commands.link import link
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
 from jirajumper.commands.update import update
@@ -164,3 +165,5 @@ app.command(
     },
     name='list',
 )(list_issues)
+
+app.command()(link)

--- a/jirajumper/commands/clone.py
+++ b/jirajumper/commands/clone.py
@@ -7,7 +7,7 @@ from jirajumper.commands.update import JIRAUpdateFailed
 
 def clone(
     context: JeevesJiraContext,
-    **kwargs: str,
+    **options: str,
 ):
     """Clone a JIRA issue."""
     parent_issue = context.obj.current_issue
@@ -16,11 +16,7 @@ def clone(
         for field in context.obj.fields
     }
 
-    update_fields = {
-        update_field.jira_name: kwargs[update_field.human_name]
-        for update_field in context.obj.fields
-        if kwargs.get(update_field.human_name)
-    }
+    update_fields = context.obj.fields.match_options(options)
 
     new_issue_fields = {
         **parent_issue_fields,

--- a/jirajumper/commands/link.py
+++ b/jirajumper/commands/link.py
@@ -1,0 +1,149 @@
+from enum import Enum
+from types import MappingProxyType
+from typing import List, Set
+
+import rich
+from jira import JIRA, Issue
+from typer import Argument
+
+from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.commands.select import normalize_issue_specifier
+
+
+class LinkType(str, Enum):   # noqa: WPS600
+    """
+    Supported Jira link types.
+
+    # FIXME Can we deduce that dynamically and store in cache?
+    """
+
+    SPLIT_FROM = 'split-from'
+    SPLIT_TO = 'split-to'
+
+    RELATES_TO = 'relates-to'
+
+    IS_CAUSED_BY = 'is-caused-by'
+    CAUSES = 'causes'
+
+    IS_DUPLICATED_BY = 'is-duplicated-by'
+    DUPLICATES = 'duplicates'
+
+    DEPENDS_ON = 'deps'
+    DEPENDED_ON_BY = 'dep'
+
+    IS_BLOCKED_BY = 'is-blocked-by'
+    BLOCKS = 'blocks'
+
+    REMOVE = 'remove'
+    CONFLUENCE = 'confluence'
+    LIST = 'list'
+
+    @property
+    def jira_name(self):
+        """Jira native name of the transition."""
+        return self.name.lower().replace('_', ' ')
+
+
+def remove_link(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    for existing_link in current_issue.fields.issuelinks:
+        linked_issue = getattr(
+            existing_link, 'outwardIssue', None,
+        ) or existing_link.inwardIssue
+
+        if linked_issue.key in issue_keys:
+            jira.delete_issue_link(existing_link.id)
+            rich.print(
+                f'{current_issue.key} and {linked_issue.key} '
+                f'are no longer connected.',
+            )
+
+
+def link_confluence(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    raise NotImplementedError('Linking to Confluence is not yet implemented.')
+
+
+def list_links(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    rich.print('Issue links:')
+    for existing_link in current_issue.fields.issuelinks:
+        linked_issue = getattr(
+            existing_link, 'outwardIssue', None,
+        ) or existing_link.inwardIssue
+
+        if linked_issue.key in issue_keys:
+            rich.print(
+                f'  * {current_issue.key} {existing_link} {linked_issue.key}',
+            )
+
+
+def link_default(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Create a link between issues."""
+    for issue_key in issue_keys:
+        jira.create_issue_link(
+            type=link_type.jira_name,
+            inwardIssue=current_issue.key,
+            outwardIssue=issue_key,
+        )
+        rich.print(
+            f'* {current_issue} {link_type} {issue_key}.',
+        )
+
+
+LINK_MANAGERS = MappingProxyType({
+    LinkType.CONFLUENCE: link_confluence,
+    LinkType.REMOVE: remove_link,
+    LinkType.LIST: list_links,
+})
+
+
+def link(
+    context: JeevesJiraContext,
+    link_type: LinkType,
+    specifiers: List[str] = Argument(None),  # noqa: WPS404, B008
+):
+    """Link current issue to some other issue."""
+    parent_issue = context.obj.current_issue
+    jira = context.obj.jira
+
+    issue_keys = {
+        normalize_issue_specifier(
+            client=jira,
+            specifier=specifier,
+            current_issue_key=parent_issue.key,
+        )
+        for specifier in specifiers or []
+    }
+
+    linker = LINK_MANAGERS.get(
+        link_type,
+        link_default,
+    )
+
+    return linker(
+        current_issue=parent_issue,
+        issue_keys=issue_keys,
+        link_type=link_type,
+        jira=jira,
+    )

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -32,6 +32,7 @@ def list_issues(
         fields=context.obj.fields,
         options=options,
     )
+    context.obj.logger.info('JQL: `%s`', jql)
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -3,16 +3,12 @@ import rich
 from jirajumper.cache.cache import JeevesJiraContext
 
 
-def list_issues(
+def list_issues(    # noqa: WPS210
     context: JeevesJiraContext,
-    **kwargs,
+    **options,
 ):
     """List JIRA issues by criteria."""
-    fields_and_values = [
-        (applicable_field, kwargs[applicable_field.human_name])
-        for applicable_field in context.obj.fields
-        if kwargs.get(applicable_field.human_name)
-    ]
+    fields_and_values = context.obj.fields.match_options(options)
 
     expressions = [
         field.to_jql(expression)

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -36,4 +36,10 @@ def list_issues(
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:
-        rich.print(f'* {issue.key} {issue.fields.summary}')
+        rich.print(
+            '* {key} [i]({status})[/i] {summary}'.format(
+                key=issue.key,
+                status=issue.fields.status,
+                summary=issue.fields.summary,
+            ),
+        )

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -1,21 +1,37 @@
+from typing import Dict
+
 import rich
 
 from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.fields import JiraFieldsRepository
+from jirajumper.fields.field import ResolvedField
 
 
-def list_issues(    # noqa: WPS210
-    context: JeevesJiraContext,
-    **options,
+def generate_jql(
+    fields: JiraFieldsRepository,
+    options: Dict[str, str],
 ):
-    """List JIRA issues by criteria."""
-    fields_and_values = context.obj.fields.match_options(options)
+    """Generate JQL string."""
+    fields_and_values = fields.match_options(options)
 
+    field: ResolvedField
     expressions = [
         field.to_jql(expression)
         for field, expression in fields_and_values
     ]
 
-    jql = ' AND '.join(expressions)
+    return ' AND '.join(expressions)
+
+
+def list_issues(
+    context: JeevesJiraContext,
+    **options,
+):
+    """List JIRA issues by criteria."""
+    jql = generate_jql(
+        fields=context.obj.fields,
+        options=options,
+    )
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:

--- a/jirajumper/commands/update.py
+++ b/jirajumper/commands/update.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 import rich
 from documented import DocumentedError
-from jira import JIRAError, JIRA
+from jira import JIRA, JIRAError
 from typer import Option
 
 from jirajumper.cache.cache import JeevesJiraContext
@@ -58,18 +58,14 @@ def update(
         None,
         help='Assignee display name or email address. Supports fuzzy search.',
     ),
-    **kwargs: str,
+    **options: str,
 ):
     """
     Update the selected JIRA issue.
 
     Use `jj jump` to select the issue to update.
     """
-    fields_and_values = [
-        (applicable_field, kwargs[applicable_field.human_name])
-        for applicable_field in context.obj.fields
-        if kwargs.get(applicable_field.human_name)
-    ]
+    fields_and_values = context.obj.fields.match_options(options)
 
     rich.print('Updating:')
     for print_field, human_value in fields_and_values:

--- a/jirajumper/fields/defaults.py
+++ b/jirajumper/fields/defaults.py
@@ -44,6 +44,18 @@ STATUS = JiraField(
 )
 
 
+STATUS_CATEGORY = JiraField(
+    jira_name='status.statusCategory',
+    human_name='status_category',
+    jql_name='statusCategory',
+    description='Issue status category: "To Do", "In Progress" and "Done".',
+
+    is_mutable=False,
+    to_jira=NotImplemented,
+    from_jira=get_name,
+)
+
+
 TYPE = JiraField(
     jira_name='issuetype',
     human_name='type',
@@ -85,7 +97,10 @@ FIELDS = JiraFieldsRepository([
     SUMMARY,
     ASSIGNEE,
     VERSION,
+
     STATUS,
+    STATUS_CATEGORY,
+
     TYPE,
     EPIC_LINK,
     PROJECT,

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -62,7 +62,7 @@ class JiraField:
     def retrieve(self, issue: Issue):
         """Retrieve the native field value from given issue."""
         return self.from_jira(
-            operator.attrgetter(self.jira_name)(issue.fields)
+            operator.attrgetter(self.jira_name)(issue.fields),
         )
 
     def store(self, human_value: HumanValue) -> Tuple[str, JiraValue]:
@@ -129,7 +129,7 @@ class ResolvedField(JiraField):
         ))
         is_multiple = len(search_values) > 1
 
-        operator = _jql_operator(
+        jql_operator = _jql_operator(
             is_multiple=is_multiple,
             is_positive=is_positive,
         )
@@ -142,8 +142,8 @@ class ResolvedField(JiraField):
         if is_multiple:
             jql_values = f'({jql_values})'
 
-        field_name = self.unresolved_jira_name
+        field_name = self.jql_name or self.unresolved_jira_name
         if ' ' in field_name:
             field_name = f'"{field_name}"'
 
-        return f'{field_name} {operator} {jql_values}'
+        return f'{field_name} {jql_operator} {jql_values}'

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -1,3 +1,4 @@
+import operator
 import re
 from dataclasses import asdict, dataclass
 from typing import Optional, Protocol, Tuple, TypeVar, Union
@@ -61,10 +62,7 @@ class JiraField:
     def retrieve(self, issue: Issue):
         """Retrieve the native field value from given issue."""
         return self.from_jira(
-            getattr(
-                issue.fields,
-                self.jira_name,
-            ),
+            operator.attrgetter(self.jira_name)(issue.fields)
         )
 
     def store(self, human_value: HumanValue) -> Tuple[str, JiraValue]:

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import asdict, dataclass
-from typing import Protocol, Tuple, TypeVar, Union, Optional
+from typing import Optional, Protocol, Tuple, TypeVar, Union
 
 from jira import Issue
 

--- a/jirajumper/fields/repository.py
+++ b/jirajumper/fields/repository.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from more_itertools import first
 
@@ -30,3 +30,19 @@ class JiraFieldsRepository(List[JiraField]):
             lambda field: field.is_writable and field.is_mutable,
             self,
         ))
+
+    def match_options(
+        self,
+        options: Dict[str, str],
+    ) -> List[Tuple[JiraField, str]]:
+        """
+        Match fields in the repo with CLI options provided by the user.
+
+        Returns a list of `(JiraField, str)` pairs, where `str` is the value
+        assigned to this field by the user.
+        """
+        return [
+            (field, options[field.human_name])
+            for field in self
+            if options.get(field.human_name)
+        ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT"
 
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT"
 
 authors = []

--- a/tasks.py
+++ b/tasks.py
@@ -56,4 +56,4 @@ def new_branch(
     ctx.run(f'git checkout -b {name}', pty=True)
     ctx.run('poetry version patch', pty=True)
     ctx.run(f'git commit -a -m "New branch: {name}"', pty=True)
-    ctx.run(f'gh pr create --fill --head')
+    ctx.run(f'gh pr create --fill --head {name}', pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -45,3 +45,15 @@ def publish(ctx: Context):
 def inc(ctx: Context):
     """Increment version number."""
     ctx.run('poetry version patch', pty=True)
+
+
+@task
+def new_branch(
+    ctx: Context,
+    name: str,
+):
+    """Create a new branch with the given name and create PR."""
+    ctx.run(f'git checkout -b {name}', pty=True)
+    ctx.run('poetry version patch', pty=True)
+    ctx.run(f'git commit -a -m "New branch: {name}"', pty=True)
+    ctx.run(f'gh pr create --fill --head')

--- a/tasks.py
+++ b/tasks.py
@@ -39,3 +39,9 @@ def fmt(ctx: Context):
 def publish(ctx: Context):
     """Publish to PyPI."""
     ctx.run('poetry publish --build', pty=True)
+
+
+@task
+def inc(ctx: Context):
+    """Increment version number."""
+    ctx.run('poetry version patch', pty=True)

--- a/tests/test_generate_jql.py
+++ b/tests/test_generate_jql.py
@@ -1,0 +1,20 @@
+from jirajumper.commands.list_issues import generate_jql
+from jirajumper.fields import JiraFieldsRepository
+from jirajumper.fields.defaults import STATUS_CATEGORY
+from jirajumper.fields.field import ResolvedField
+
+
+def test_status_category():
+    status_category = ResolvedField(
+        human_name='status_category',
+        jira_name='statusCategory',
+        unresolved_jira_name='statusCategory',
+        description='',
+    )
+
+    fields = JiraFieldsRepository([status_category])
+    options = {'status_category': 'boo'}
+    assert generate_jql(
+        fields=fields,
+        options=options,
+    ) == 'statusCategory = "boo"'

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,7 @@
+from jirajumper.fields.defaults import STATUS_CATEGORY
+
+
+def test_status_category():
+    resolved_field = STATUS_CATEGORY.resolve(field_key_by_name={})
+    assert resolved_field.jira_name == 'status.statusCategory'
+    assert resolved_field.jql_name == 'statusCategory'


### PR DESCRIPTION
- Savepoint before I break everything
- Cosmetic change
- Update `jj --format json jump` logic to avoid usage of obsolete cached fields logic
- Remove bunch of dead code
- Transparently control the location of the cache file
- Implement `inv lint` and `inv format` commands
- Support for `jj update --epic` implemented
- Draft implementation for `jj clone`
- Resolve JIRA field names transparently and reduce boilerplate
- Implemented `jj assign` command
- Do a little `inv format`
- Add `is_mutable` characteristic for fields
- Factor `assign` into `update`
- Draft implementation of `jj list``
- Fix a bug at `jj list --epic`
- Get rid of some boilerplate
- Add two real unit tests
- Add `--log-level` option and fix `statusCategory` filtering
- Add `inv inc` and discover that we cannot publish on PyPI
- New branch: inv-new-branch
- Create `inv new-branch` draft command
- Implement `jj link`
