### PR TITLE
jj roadmap

### DIFF
--- a/jirajumper/cache/cache.py
+++ b/jirajumper/cache/cache.py
@@ -1,6 +1,6 @@
-import json
 from dataclasses import dataclass
 from functools import cached_property
+from logging import Logger
 from pathlib import Path
 from typing import Optional
 
@@ -43,6 +43,7 @@ def field_key_by_name(jira: JIRA) -> FieldKeyByName:
 class GlobalOptions:
     """Global jeeves-jira configuration options."""
 
+    logger: Logger
     output_format: OutputFormat
     jira: JIRA
     cache_path: Path

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -13,7 +13,7 @@ from jirajumper.commands.clone import clone
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
 from jirajumper.commands.update import update
-from jirajumper.fields import FIELDS, JiraField
+from jirajumper.fields import FIELDS, JiraField, JiraFieldsRepository
 from jirajumper.models import OutputFormat
 
 app = Typer(
@@ -54,7 +54,7 @@ def global_options(
     context.obj = GlobalOptions(
         output_format=format,
         jira=jira(),
-        fields=list(resolved_fields),
+        fields=JiraFieldsRepository(resolved_fields),
         cache_path=cache_path,
     )
 
@@ -81,9 +81,9 @@ class AutoOptionsCommand(TyperCommand):
         ]
 
         existing_params = list(filterfalse(
-            lambda param: (
-                isinstance(param, TyperArgument) and
-                param.name == 'kwargs'
+            lambda existing_param: (
+                isinstance(existing_param, TyperArgument) and
+                existing_param.name == 'options'
             ),
             kwargs.get('params', []),
         ))

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -15,6 +15,7 @@ from jirajumper.cache.cache import GlobalOptions, field_key_by_name
 from jirajumper.client import jira
 from jirajumper.commands.clone import clone
 from jirajumper.commands.fork import fork
+from jirajumper.commands.graph import graph
 from jirajumper.commands.link import link
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
@@ -173,5 +174,13 @@ app.command(
     },
     name='list',
 )(list_issues)
+
+app.command(
+    cls=AutoOptionsCommand,
+    context_settings={
+        'ignore_unknown_options': True,
+    },
+    name='graph',
+)(graph)
 
 app.command()(link)

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -74,7 +74,7 @@ class AutoOptionsCommand(TyperCommand):
 
         custom_options = [
             click.Option(
-                [f'--{field.human_name}'],
+                [f'--{field.human_name.replace("_", "-")}'],
                 help=field.description,
             )
             for field in fields

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -14,6 +14,7 @@ from typer.core import TyperArgument, TyperCommand
 from jirajumper.cache.cache import GlobalOptions, field_key_by_name
 from jirajumper.client import jira
 from jirajumper.commands.clone import clone
+from jirajumper.commands.fork import fork
 from jirajumper.commands.link import link
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
@@ -149,6 +150,13 @@ app.command(
         'ignore_unknown_options': True,
     },
 )(clone)
+
+app.command(
+    cls=CloneCommand,
+    context_settings={
+        'ignore_unknown_options': True,
+    },
+)(fork)
 
 app.command(
     cls=UpdateCommand,

--- a/jirajumper/cli.py
+++ b/jirajumper/cli.py
@@ -14,6 +14,7 @@ from typer.core import TyperArgument, TyperCommand
 from jirajumper.cache.cache import GlobalOptions, field_key_by_name
 from jirajumper.client import jira
 from jirajumper.commands.clone import clone
+from jirajumper.commands.link import link
 from jirajumper.commands.list_issues import list_issues
 from jirajumper.commands.select import jump
 from jirajumper.commands.update import update
@@ -164,3 +165,5 @@ app.command(
     },
     name='list',
 )(list_issues)
+
+app.command()(link)

--- a/jirajumper/commands/clone.py
+++ b/jirajumper/commands/clone.py
@@ -7,7 +7,7 @@ from jirajumper.commands.update import JIRAUpdateFailed
 
 def clone(
     context: JeevesJiraContext,
-    **kwargs: str,
+    **options: str,
 ):
     """Clone a JIRA issue."""
     parent_issue = context.obj.current_issue
@@ -16,11 +16,7 @@ def clone(
         for field in context.obj.fields
     }
 
-    update_fields = {
-        update_field.jira_name: kwargs[update_field.human_name]
-        for update_field in context.obj.fields
-        if kwargs.get(update_field.human_name)
-    }
+    update_fields = context.obj.fields.match_options(options)
 
     new_issue_fields = {
         **parent_issue_fields,

--- a/jirajumper/commands/clone.py
+++ b/jirajumper/commands/clone.py
@@ -21,7 +21,6 @@ def clone(
         for field in context.obj.fields
         if field.is_writable()
     )
-    # raise ValueError(parent_issue_fields)
 
     resolved_fields = context.obj.fields.match_options(options)
 
@@ -35,8 +34,6 @@ def clone(
         **update_fields,
     }
 
-    # raise ValueError(new_issue_fields)
-
     try:
         issue = context.obj.jira.create_issue(fields=new_issue_fields)
     except JIRAError as err:
@@ -45,7 +42,9 @@ def clone(
             fields=context.obj.fields,
         ) from err
 
-    assignee = getattr(parent_issue.fields.assignee, 'displayName', assignee)
+    if not assignee:
+        assignee = getattr(parent_issue.fields.assignee, 'displayName', None)
+
     if assignee:
         assign(
             jira=context.obj.jira,

--- a/jirajumper/commands/fork.py
+++ b/jirajumper/commands/fork.py
@@ -1,0 +1,35 @@
+import rich
+from jira import JIRAError
+from typer import Option
+
+from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.commands.clone import clone
+from jirajumper.commands.link import LinkType, link
+from jirajumper.commands.select import jump
+from jirajumper.commands.update import JIRAUpdateFailed
+
+
+def fork(
+    context: JeevesJiraContext,
+    link_type: LinkType = Option(LinkType.DEPENDED_ON_BY, '--type'),
+    stay: bool = False,
+    **options: str,
+):
+    """Fork a JIRA issue."""
+    child_issue = clone(
+        context=context,
+        stay=True,
+        **options,
+    )
+
+    link(
+        context=context,
+        link_type=link_type,
+        specifiers=[child_issue.key],
+    )
+
+    if not stay:
+        jump(
+            context=context,
+            specifier=child_issue.key,
+        )

--- a/jirajumper/commands/fork.py
+++ b/jirajumper/commands/fork.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import rich
 from jira import JIRAError
 from typer import Option
 
+from jirajumper import default_options
 from jirajumper.cache.cache import JeevesJiraContext
 from jirajumper.commands.clone import clone
 from jirajumper.commands.link import LinkType, link
@@ -13,12 +16,14 @@ def fork(
     context: JeevesJiraContext,
     link_type: LinkType = Option(LinkType.DEPENDED_ON_BY, '--type'),
     stay: bool = False,
+    assignee: Optional[str] = default_options.ASSIGNEE,
     **options: str,
 ):
     """Fork a JIRA issue."""
     child_issue = clone(
         context=context,
         stay=True,
+        assignee=assignee,
         **options,
     )
 

--- a/jirajumper/commands/fork.py
+++ b/jirajumper/commands/fork.py
@@ -14,9 +14,10 @@ from jirajumper.commands.update import JIRAUpdateFailed
 
 def fork(
     context: JeevesJiraContext,
-    link_type: LinkType = Option(LinkType.DEPENDED_ON_BY, '--type'),
+    link_type: LinkType = Option(LinkType.BLOCKS, '--link'),
     stay: bool = False,
     assignee: Optional[str] = default_options.ASSIGNEE,
+    summary: str = default_options.SUMMARY,
     **options: str,
 ):
     """Fork a JIRA issue."""
@@ -24,6 +25,7 @@ def fork(
         context=context,
         stay=True,
         assignee=assignee,
+        summary=summary,
         **options,
     )
 

--- a/jirajumper/commands/graph.py
+++ b/jirajumper/commands/graph.py
@@ -1,0 +1,128 @@
+import html
+import textwrap
+from types import MappingProxyType
+
+import graphviz
+
+from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.client import issue_url
+from jirajumper.commands.list_issues import generate_jql
+
+DEFAULT_COLOR_MAP = MappingProxyType({
+    'Code Review': '#BD34D1',  # Pink
+    'In Review': '#BD34D1',  # Pink
+    'Refinement': '#897A5F',  # Brown
+    'In Progress': '#F7C325',  # Yellow
+    # 'Queued': '#AC6363',      # Crimson
+    'Rejected': '#AC6363',  # Crimson
+    'Queued': '#D3455B',  # Red
+    # 'Draft': '#CCCCCC',       # Gray
+    # 'Draft': '#E8833A',  # Orange
+    'Draft': '#EEEEEE',  # Light Gray
+    # 'Closed': '#E8833A',      # Orange
+    'Closed': '#CCCCCC',  # Gray
+    'Put On Ice': '#2C88D9',  # Blue
+    'QA': '#730FC3',  # Purple
+    'In Testing': '#730FC3',  # Purple
+    # 'Done': '#207868',        # Green
+    'Done': '#1AAE9F',  # Mint
+})
+
+
+def graph(
+    context: JeevesJiraContext,
+    **options,
+):
+    """List JIRA issues by criteria."""
+    jql = generate_jql(
+        fields=context.obj.fields,
+        options=options,
+    )
+
+    logger = context.obj.logger
+    logger.info('JQL: `%s`', jql)
+
+    jira = context.obj.jira
+    issues = jira.search_issues(jql, maxResults=None)
+
+    graph = graphviz.Digraph(
+        comment='Jira task links',
+        graph_attr={
+            'rankdir': 'LR',
+        }
+    )
+    for issue in issues:
+        color = DEFAULT_COLOR_MAP.get(
+            issue.fields.status.name,
+            'white',
+        )
+
+        wrapped_summary = '<br/>'.join(
+            textwrap.wrap(
+                html.escape(issue.fields.summary.replace('"', '')),
+                width=20,
+            )
+        )
+
+        if (
+            issue.fields.issuetype.name == 'Epic' and
+            issue.fields.status.statusCategory.name != 'Done'
+        ):
+            logger.info('Retrieving children for epic %s...', issue)
+            epic_children = jira.search_issues(
+                f'"Epic Link" = {issue.key}',
+                maxResults=None,
+            )
+            total_count = len(epic_children)
+            done_count = len([
+                issue
+                for issue in epic_children
+                if issue.fields.status.statusCategory.name == 'Done'
+            ])
+            progress = f'<I>[{done_count} of {total_count}]</I>'
+        else:
+            progress = ''
+
+        label = textwrap.dedent(f'''
+            <TABLE BGCOLOR="{color}" BORDER="0" CELLBORDER="1" CELLSPACING="0">
+                <TR><TD ALIGN="left"><B>{issue.key}</B> <I>{issue.fields.issuetype}</I></TD></TR>
+                <TR><TD ALIGN="left">{wrapped_summary}</TD></TR>
+                <TR><TD ALIGN="left">{issue.fields.assignee}</TD></TR>
+                <TR><TD ALIGN="left">{issue.fields.status} {progress}</TD></TR>
+            </TABLE>
+        ''')
+
+        graph.node(
+            issue.key,
+            f'<{label}>',
+            shape='none',
+            href=issue_url(context.obj.jira.server_url, issue.key),
+            target='_blank',
+        )
+
+        links = issue.fields.issuelinks
+        for link in links:
+            linked_issue = getattr(link, 'inwardIssue', None)
+            if not linked_issue:
+                continue
+
+            if (
+                linked_issue.fields.status.name == 'Put On Ice' and
+                issue.fields.status.name in {'In Progress', 'Queued'}
+            ):
+                edge_options = {'color': '#D3455B', 'fontcolor': '#D3455B'}
+            else:
+                edge_options = {}
+
+            graph.edge(
+                linked_issue.key,
+                issue.key,
+                link.type.name,
+                **edge_options,
+            )
+
+    graph.render(
+        '/tmp/jeeves-jira-roadmap',
+        format='png',
+        view=True,
+    )

--- a/jirajumper/commands/link.py
+++ b/jirajumper/commands/link.py
@@ -1,0 +1,149 @@
+from enum import Enum
+from types import MappingProxyType
+from typing import List, Set
+
+import rich
+from jira import JIRA, Issue
+from typer import Argument
+
+from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.commands.select import normalize_issue_specifier
+
+
+class LinkType(str, Enum):   # noqa: WPS600
+    """
+    Supported Jira link types.
+
+    # FIXME Can we deduce that dynamically and store in cache?
+    """
+
+    SPLIT_FROM = 'split-from'
+    SPLIT_TO = 'split-to'
+
+    RELATES_TO = 'relates-to'
+
+    IS_CAUSED_BY = 'is-caused-by'
+    CAUSES = 'causes'
+
+    IS_DUPLICATED_BY = 'is-duplicated-by'
+    DUPLICATES = 'duplicates'
+
+    DEPENDS_ON = 'deps'
+    DEPENDED_ON_BY = 'dep'
+
+    IS_BLOCKED_BY = 'is-blocked-by'
+    BLOCKS = 'blocks'
+
+    REMOVE = 'remove'
+    CONFLUENCE = 'confluence'
+    LIST = 'list'
+
+    @property
+    def jira_name(self):
+        """Jira native name of the transition."""
+        return self.name.lower().replace('_', ' ')
+
+
+def remove_link(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    for existing_link in current_issue.fields.issuelinks:
+        linked_issue = getattr(
+            existing_link, 'outwardIssue', None,
+        ) or existing_link.inwardIssue
+
+        if linked_issue.key in issue_keys:
+            jira.delete_issue_link(existing_link.id)
+            rich.print(
+                f'{current_issue.key} and {linked_issue.key} '
+                f'are no longer connected.',
+            )
+
+
+def link_confluence(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    raise NotImplementedError('Linking to Confluence is not yet implemented.')
+
+
+def list_links(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Remove links to a number of issues."""
+    rich.print('Issue links:')
+    for existing_link in current_issue.fields.issuelinks:
+        linked_issue = getattr(
+            existing_link, 'outwardIssue', None,
+        ) or existing_link.inwardIssue
+
+        if linked_issue.key in issue_keys:
+            rich.print(
+                f'  * {current_issue.key} {existing_link} {linked_issue.key}',
+            )
+
+
+def link_default(
+    current_issue: Issue,
+    issue_keys: Set[str],
+    link_type: LinkType,
+    jira: JIRA,
+):
+    """Create a link between issues."""
+    for issue_key in issue_keys:
+        jira.create_issue_link(
+            type=link_type.jira_name,
+            inwardIssue=current_issue.key,
+            outwardIssue=issue_key,
+        )
+        rich.print(
+            f'* {current_issue} {link_type} {issue_key}.',
+        )
+
+
+LINK_MANAGERS = MappingProxyType({
+    LinkType.CONFLUENCE: link_confluence,
+    LinkType.REMOVE: remove_link,
+    LinkType.LIST: list_links,
+})
+
+
+def link(
+    context: JeevesJiraContext,
+    link_type: LinkType,
+    specifiers: List[str] = Argument(None),  # noqa: WPS404, B008
+):
+    """Link current issue to some other issue."""
+    parent_issue = context.obj.current_issue
+    jira = context.obj.jira
+
+    issue_keys = {
+        normalize_issue_specifier(
+            client=jira,
+            specifier=specifier,
+            current_issue_key=parent_issue.key,
+        )
+        for specifier in specifiers or []
+    }
+
+    linker = LINK_MANAGERS.get(
+        link_type,
+        link_default,
+    )
+
+    return linker(
+        current_issue=parent_issue,
+        issue_keys=issue_keys,
+        link_type=link_type,
+        jira=jira,
+    )

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -32,6 +32,7 @@ def list_issues(
         fields=context.obj.fields,
         options=options,
     )
+    context.obj.logger.info('JQL: `%s`', jql)
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -3,16 +3,12 @@ import rich
 from jirajumper.cache.cache import JeevesJiraContext
 
 
-def list_issues(
+def list_issues(    # noqa: WPS210
     context: JeevesJiraContext,
-    **kwargs,
+    **options,
 ):
     """List JIRA issues by criteria."""
-    fields_and_values = [
-        (applicable_field, kwargs[applicable_field.human_name])
-        for applicable_field in context.obj.fields
-        if kwargs.get(applicable_field.human_name)
-    ]
+    fields_and_values = context.obj.fields.match_options(options)
 
     expressions = [
         field.to_jql(expression)

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -36,4 +36,10 @@ def list_issues(
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:
-        rich.print(f'* {issue.key} {issue.fields.summary}')
+        rich.print(
+            '* {key} [i]({status})[/i] {summary}'.format(
+                key=issue.key,
+                status=issue.fields.status,
+                summary=issue.fields.summary,
+            ),
+        )

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -1,21 +1,37 @@
+from typing import Dict
+
 import rich
 
 from jirajumper.cache.cache import JeevesJiraContext
+from jirajumper.fields import JiraFieldsRepository
+from jirajumper.fields.field import ResolvedField
 
 
-def list_issues(    # noqa: WPS210
-    context: JeevesJiraContext,
-    **options,
+def generate_jql(
+    fields: JiraFieldsRepository,
+    options: Dict[str, str],
 ):
-    """List JIRA issues by criteria."""
-    fields_and_values = context.obj.fields.match_options(options)
+    """Generate JQL string."""
+    fields_and_values = fields.match_options(options)
 
+    field: ResolvedField
     expressions = [
         field.to_jql(expression)
         for field, expression in fields_and_values
     ]
 
-    jql = ' AND '.join(expressions)
+    return ' AND '.join(expressions)
+
+
+def list_issues(
+    context: JeevesJiraContext,
+    **options,
+):
+    """List JIRA issues by criteria."""
+    jql = generate_jql(
+        fields=context.obj.fields,
+        options=options,
+    )
     issues = context.obj.jira.search_issues(jql, maxResults=None)
 
     for issue in issues:

--- a/jirajumper/commands/list_issues.py
+++ b/jirajumper/commands/list_issues.py
@@ -37,9 +37,10 @@ def list_issues(
 
     for issue in issues:
         rich.print(
-            '* {key} [i]({status})[/i] {summary}'.format(
+            '* {key} [i]({status} / {assignee})[/i] {summary}'.format(
                 key=issue.key,
                 status=issue.fields.status,
+                assignee=issue.fields.assignee,
                 summary=issue.fields.summary,
             ),
         )

--- a/jirajumper/commands/update.py
+++ b/jirajumper/commands/update.py
@@ -4,8 +4,8 @@ from typing import Dict, Optional
 import rich
 from documented import DocumentedError
 from jira import JIRA, JIRAError
-from typer import Option
 
+from jirajumper import default_options
 from jirajumper.cache.cache import JeevesJiraContext
 from jirajumper.fields import JiraFieldsRepository
 
@@ -54,10 +54,7 @@ def assign(jira: JIRA, key: str, assignee: str):
 
 def update(
     context: JeevesJiraContext,
-    assignee: Optional[str] = Option(
-        None,
-        help='Assignee display name or email address. Supports fuzzy search.',
-    ),
+    assignee: Optional[str] = default_options.ASSIGNEE,
     **options: str,
 ):
     """

--- a/jirajumper/commands/update.py
+++ b/jirajumper/commands/update.py
@@ -3,7 +3,7 @@ from typing import Dict, Optional
 
 import rich
 from documented import DocumentedError
-from jira import JIRAError, JIRA
+from jira import JIRA, JIRAError
 from typer import Option
 
 from jirajumper.cache.cache import JeevesJiraContext
@@ -58,18 +58,14 @@ def update(
         None,
         help='Assignee display name or email address. Supports fuzzy search.',
     ),
-    **kwargs: str,
+    **options: str,
 ):
     """
     Update the selected JIRA issue.
 
     Use `jj jump` to select the issue to update.
     """
-    fields_and_values = [
-        (applicable_field, kwargs[applicable_field.human_name])
-        for applicable_field in context.obj.fields
-        if kwargs.get(applicable_field.human_name)
-    ]
+    fields_and_values = context.obj.fields.match_options(options)
 
     rich.print('Updating:')
     for print_field, human_value in fields_and_values:

--- a/jirajumper/default_options.py
+++ b/jirajumper/default_options.py
@@ -1,0 +1,6 @@
+from typer import Option
+
+ASSIGNEE = Option(
+    None,
+    help='Assignee display name or email address. Supports fuzzy search.',
+)

--- a/jirajumper/default_options.py
+++ b/jirajumper/default_options.py
@@ -1,6 +1,11 @@
-from typer import Option
+from typer import Option, Argument
 
 ASSIGNEE = Option(
     None,
     help='Assignee display name or email address. Supports fuzzy search.',
+)
+
+SUMMARY = Argument(
+    ...,
+    help='Issue summary.'
 )

--- a/jirajumper/fields/defaults.py
+++ b/jirajumper/fields/defaults.py
@@ -44,6 +44,18 @@ STATUS = JiraField(
 )
 
 
+STATUS_CATEGORY = JiraField(
+    jira_name='status.statusCategory',
+    human_name='status_category',
+    jql_name='statusCategory',
+    description='Issue status category: "To Do", "In Progress" and "Done".',
+
+    is_mutable=False,
+    to_jira=NotImplemented,
+    from_jira=get_name,
+)
+
+
 TYPE = JiraField(
     jira_name='issuetype',
     human_name='type',
@@ -85,7 +97,10 @@ FIELDS = JiraFieldsRepository([
     SUMMARY,
     ASSIGNEE,
     VERSION,
+
     STATUS,
+    STATUS_CATEGORY,
+
     TYPE,
     EPIC_LINK,
     PROJECT,

--- a/jirajumper/fields/defaults.py
+++ b/jirajumper/fields/defaults.py
@@ -72,8 +72,9 @@ PROJECT = JiraField(
 
     # It is impossible to easily migrate across projects.
     is_mutable=False,
+
     to_jira=lambda project_key: {'key': project_key},
-    from_jira=get_name,
+    from_jira=operator.attrgetter('key'),
 )
 
 DESCRIPTION = JiraField(

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -62,7 +62,7 @@ class JiraField:
     def retrieve(self, issue: Issue):
         """Retrieve the native field value from given issue."""
         return self.from_jira(
-            operator.attrgetter(self.jira_name)(issue.fields)
+            operator.attrgetter(self.jira_name)(issue.fields),
         )
 
     def store(self, human_value: HumanValue) -> Tuple[str, JiraValue]:
@@ -129,7 +129,7 @@ class ResolvedField(JiraField):
         ))
         is_multiple = len(search_values) > 1
 
-        operator = _jql_operator(
+        jql_operator = _jql_operator(
             is_multiple=is_multiple,
             is_positive=is_positive,
         )
@@ -142,8 +142,8 @@ class ResolvedField(JiraField):
         if is_multiple:
             jql_values = f'({jql_values})'
 
-        field_name = self.unresolved_jira_name
+        field_name = self.jql_name or self.unresolved_jira_name
         if ' ' in field_name:
             field_name = f'"{field_name}"'
 
-        return f'{field_name} {operator} {jql_values}'
+        return f'{field_name} {jql_operator} {jql_values}'

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -1,3 +1,4 @@
+import operator
 import re
 from dataclasses import asdict, dataclass
 from typing import Optional, Protocol, Tuple, TypeVar, Union
@@ -61,10 +62,7 @@ class JiraField:
     def retrieve(self, issue: Issue):
         """Retrieve the native field value from given issue."""
         return self.from_jira(
-            getattr(
-                issue.fields,
-                self.jira_name,
-            ),
+            operator.attrgetter(self.jira_name)(issue.fields)
         )
 
     def store(self, human_value: HumanValue) -> Tuple[str, JiraValue]:

--- a/jirajumper/fields/field.py
+++ b/jirajumper/fields/field.py
@@ -1,6 +1,6 @@
 import re
 from dataclasses import asdict, dataclass
-from typing import Protocol, Tuple, TypeVar, Union, Optional
+from typing import Optional, Protocol, Tuple, TypeVar, Union
 
 from jira import Issue
 

--- a/jirajumper/fields/repository.py
+++ b/jirajumper/fields/repository.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from more_itertools import first
 
@@ -30,3 +30,19 @@ class JiraFieldsRepository(List[JiraField]):
             lambda field: field.is_writable and field.is_mutable,
             self,
         ))
+
+    def match_options(
+        self,
+        options: Dict[str, str],
+    ) -> List[Tuple[JiraField, str]]:
+        """
+        Match fields in the repo with CLI options provided by the user.
+
+        Returns a list of `(JiraField, str)` pairs, where `str` is the value
+        assigned to this field by the user.
+        """
+        return [
+            (field, options[field.human_name])
+            for field in self
+            if options.get(field.human_name)
+        ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -482,6 +482,19 @@ gitdb = ">=4.0.1,<5"
 typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.10\""}
 
 [[package]]
+name = "graphviz"
+version = "0.18"
+description = "Simple Python interface for Graphviz"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["tox (>=3)", "flake8", "pep8-naming", "wheel", "twine"]
+docs = ["sphinx (>=1.8)", "sphinx-autodoc-typehints", "sphinx-rtd-theme"]
+test = ["pytest (>=6)", "pytest-mock (>=2)", "mock (>=3)", "pytest-cov"]
+
+[[package]]
 name = "idna"
 version = "3.2"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -589,11 +602,12 @@ trio = ["trio", "async-generator"]
 
 [[package]]
 name = "jira"
-version = "3.0.1"
+version = "3.1.0rc1"
 description = "Python library for interacting with JIRA via REST APIs."
 category = "main"
 optional = false
 python-versions = ">=3.6"
+develop = false
 
 [package.dependencies]
 defusedxml = "*"
@@ -607,6 +621,13 @@ async = ["requests-futures (>=0.9.7)"]
 cli = ["ipython (>=4.0.0)"]
 docs = ["Sphinx (>=2.2.0)", "sphinx-rtd-theme (>=0.4.3)"]
 opt = ["filemagic (>=1.6)", "pyjwt", "requests-jwt", "requests-kerberos"]
+test = ["docutils (>=0.12)", "flaky", "MarkupSafe (>=0.23)", "oauthlib", "py (>=1.4)", "pytest-cache", "pytest-cov", "pytest-instafail", "pytest-sugar", "pytest-timeout (>=1.3.1)", "pytest-xdist (>=2.2)", "pytest (>=6.0.0,<7.0)", "PyYAML (>=5.1)", "requests-mock", "requires.io", "tenacity", "wheel (>=0.24.0)", "xmlrunner (>=1.7.7)", "yanc (>=0.3.3)"]
+
+[package.source]
+type = "git"
+url = "https://github.com/pycontribs/jira.git"
+reference = "3.1.0rc1"
+resolved_reference = "73d056e4ec5752327557014de90455e561b2590d"
 
 [[package]]
 name = "keyring"
@@ -1256,7 +1277,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<3.10"
-content-hash = "c698ffaf0a77922b3de30f6cc014b694ddffebb784cf4cc3c8b10e6127920e09"
+content-hash = "25f83e71adbe485f33c0d6ef980ccd752efce2964d9f6a60e4ed35df868f5296"
 
 [metadata.files]
 appnope = [
@@ -1524,6 +1545,10 @@ gitpython = [
     {file = "GitPython-3.1.24-py3-none-any.whl", hash = "sha256:dc0a7f2f697657acc8d7f89033e8b1ea94dd90356b2983bca89dc8d2ab3cc647"},
     {file = "GitPython-3.1.24.tar.gz", hash = "sha256:df83fdf5e684fef7c6ee2c02fc68a5ceb7e7e759d08b694088d0cacb4eba59e5"},
 ]
+graphviz = [
+    {file = "graphviz-0.18-py3-none-any.whl", hash = "sha256:f8bab3bf3eda40ab259bb96f786811b5dec6fd6957fa70a5b1977534e1ee2a40"},
+    {file = "graphviz-0.18.zip", hash = "sha256:0f04e5f939d3a839b524283d590e941892c56e75e60e0f5238c431264f490022"},
+]
 idna = [
     {file = "idna-3.2-py3-none-any.whl", hash = "sha256:14475042e284991034cb48e06f6851428fb14c4dc953acd9be9a5e95c7b6dd7a"},
     {file = "idna-3.2.tar.gz", hash = "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"},
@@ -1552,10 +1577,7 @@ jeepney = [
     {file = "jeepney-0.7.1-py3-none-any.whl", hash = "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac"},
     {file = "jeepney-0.7.1.tar.gz", hash = "sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f"},
 ]
-jira = [
-    {file = "jira-3.0.1-py3-none-any.whl", hash = "sha256:bc8d1dfeb51eb27ec90b455f2013e675b309dada00095936e65e0459a2f0df84"},
-    {file = "jira-3.0.1.tar.gz", hash = "sha256:5bd8f4199632bf91fcfb4ba25ad2226991d403923b75f7cd2b051b4571492831"},
-]
+jira = []
 keyring = [
     {file = "keyring-23.2.1-py3-none-any.whl", hash = "sha256:bd2145a237ed70c8ce72978b497619ddfcae640b6dcf494402d5143e37755c6e"},
     {file = "keyring-23.2.1.tar.gz", hash = "sha256:6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.5"
+version = "0.1.6"
 license = "MIT"
 
 authors = []
@@ -38,6 +38,7 @@ pydantic = "^1.8.2"
 documented = "^0.1.1"
 rich = "^10.12.0"
 more-itertools = "^8.10.0"
+graphviz = "^0.18"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.2"
+version = "0.1.3"
 license = "MIT"
 
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.4"
+version = "0.1.5"
 license = "MIT"
 
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.1"
+version = "0.1.2"
 license = "MIT"
 
 authors = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "jirajumper"
 description = "Yet another JIRA issue manager CLI with emphasis on task chains."
-version = "0.1.3"
+version = "0.1.4"
 license = "MIT"
 
 authors = []

--- a/tasks.py
+++ b/tasks.py
@@ -56,4 +56,4 @@ def new_branch(
     ctx.run(f'git checkout -b {name}', pty=True)
     ctx.run('poetry version patch', pty=True)
     ctx.run(f'git commit -a -m "New branch: {name}"', pty=True)
-    ctx.run(f'gh pr create --fill --head')
+    ctx.run(f'gh pr create --fill --head {name}', pty=True)

--- a/tasks.py
+++ b/tasks.py
@@ -45,3 +45,15 @@ def publish(ctx: Context):
 def inc(ctx: Context):
     """Increment version number."""
     ctx.run('poetry version patch', pty=True)
+
+
+@task
+def new_branch(
+    ctx: Context,
+    name: str,
+):
+    """Create a new branch with the given name and create PR."""
+    ctx.run(f'git checkout -b {name}', pty=True)
+    ctx.run('poetry version patch', pty=True)
+    ctx.run(f'git commit -a -m "New branch: {name}"', pty=True)
+    ctx.run(f'gh pr create --fill --head')

--- a/tasks.py
+++ b/tasks.py
@@ -39,3 +39,9 @@ def fmt(ctx: Context):
 def publish(ctx: Context):
     """Publish to PyPI."""
     ctx.run('poetry publish --build', pty=True)
+
+
+@task
+def inc(ctx: Context):
+    """Increment version number."""
+    ctx.run('poetry version patch', pty=True)

--- a/tests/test_generate_jql.py
+++ b/tests/test_generate_jql.py
@@ -1,0 +1,20 @@
+from jirajumper.commands.list_issues import generate_jql
+from jirajumper.fields import JiraFieldsRepository
+from jirajumper.fields.defaults import STATUS_CATEGORY
+from jirajumper.fields.field import ResolvedField
+
+
+def test_status_category():
+    status_category = ResolvedField(
+        human_name='status_category',
+        jira_name='statusCategory',
+        unresolved_jira_name='statusCategory',
+        description='',
+    )
+
+    fields = JiraFieldsRepository([status_category])
+    options = {'status_category': 'boo'}
+    assert generate_jql(
+        fields=fields,
+        options=options,
+    ) == 'statusCategory = "boo"'

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,7 @@
+from jirajumper.fields.defaults import STATUS_CATEGORY
+
+
+def test_status_category():
+    resolved_field = STATUS_CATEGORY.resolve(field_key_by_name={})
+    assert resolved_field.jira_name == 'status.statusCategory'
+    assert resolved_field.jql_name == 'statusCategory'


### PR DESCRIPTION
- Savepoint before I break everything
- Cosmetic change
- Update `jj --format json jump` logic to avoid usage of obsolete cached fields logic
- Remove bunch of dead code
- Transparently control the location of the cache file
- Implement `inv lint` and `inv format` commands
- Support for `jj update --epic` implemented
- Draft implementation for `jj clone`
- Resolve JIRA field names transparently and reduce boilerplate
- Implemented `jj assign` command
- Do a little `inv format`
- Add `is_mutable` characteristic for fields
- Factor `assign` into `update`
- Draft implementation of `jj list``
- Fix a bug at `jj list --epic`
- Get rid of some boilerplate
- Add two real unit tests
- Add `--log-level` option and fix `statusCategory` filtering
- Add `inv inc` and discover that we cannot publish on PyPI
- New branch: inv-new-branch
- Create `inv new-branch` draft command
- Implement `jj link`
- Implement `jj fork`
- Support assignee and project in `jj fork` command
- The `summary` field is now a special case for `jj fork`
- Implement `jj graph`
